### PR TITLE
Add time-series worm trajectories

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # Slick 1.0.3
 
+- `plotTimeseries()` now overplots a random selection of individual simulation trajectories ("worms"), with 10 worms shown by default.
 - `OMs@Preset` is now a flat named list of `Design` row indices, matching the format
   already used by `MPs@Preset` (and the performance-metric `Preset`s), instead of a
   nested list keyed by `Factor`. The old nested format is still accepted and is

--- a/R/fct_plotTimeseries.R
+++ b/R/fct_plotTimeseries.R
@@ -39,6 +39,8 @@
 #' @param inc_y_label Include the label for the y-axis?
 #' @param sims Optional. Numeric values indicating the simulations to include. Defaults
 #' to all.
+#' @param worms Number of randomly selected individual simulation trajectories to
+#' overplot. Defaults to 10. Set to 0 to omit individual trajectories.
 #' @param lang Optional. Language (if supported in Slick Object). Either 'en', 'es', 'fr', or 'pt'
 #'
 #' @seealso [Timeseries()], [Timeseries-class()]
@@ -79,6 +81,7 @@ plotTimeseries <- function(slick,
                            lim_name='Limit',
                            inc_y_label=TRUE,
                            sims=NULL,
+                           worms=10,
                            lang='en') {
 
   if (!methods::is(slick, 'Slick'))
@@ -130,6 +133,14 @@ plotTimeseries <- function(slick,
 
   if (is.null(sims)) {
     sims <- 1:dim(values)[1]
+  }
+  if (length(worms) != 1 || is.na(worms) || worms < 0 || worms != as.integer(worms)) {
+    cli::cli_abort("`worms` must be a single non-negative integer.")
+  }
+  worm_sims <- if (worms > 0) {
+    sims[sample.int(length(sims), min(worms, length(sims)))]
+  } else {
+    numeric()
   }
 
   oms <- 1:nOM
@@ -191,6 +202,37 @@ plotTimeseries <- function(slick,
                              fill=fill_ribbon1, col=col_ribbon1, alpha=alpha1)
     }
 
+    if (length(worm_sims) > 0) {
+      if (byOM) {
+        worm.values <- values[worm_sims, oms, 1, PI, 1:hist.yr.ind, drop=FALSE]
+        worm_df <- data.frame(
+          Sim=rep(worm_sims, times=nOM * length(hist.yrs)),
+          OM=rep(om_names, each=length(worm_sims), times=length(hist.yrs)),
+          x=rep(hist.yrs, each=length(worm_sims) * nOM),
+          y=as.vector(worm.values)
+        )
+        worm_df$OM <- factor(worm_df$OM, levels=om_names, ordered=TRUE)
+        p <- p + ggplot2::geom_line(
+          ggplot2::aes(x=x, y=y, group=interaction(Sim, OM)),
+          data=worm_df, color=col_line, alpha=0.25, linewidth=0.3
+        )
+      } else {
+        worm.values <- apply(
+          values[worm_sims, oms, 1, PI, 1:hist.yr.ind, drop=FALSE],
+          c(1, 5), mean, na.rm=TRUE
+        )
+        worm_df <- data.frame(
+          Sim=rep(worm_sims, times=length(hist.yrs)),
+          x=rep(hist.yrs, each=length(worm_sims)),
+          y=as.vector(worm.values)
+        )
+        p <- p + ggplot2::geom_line(
+          ggplot2::aes(x=x, y=y, group=Sim),
+          data=worm_df, color=col_line, alpha=0.25, linewidth=0.3
+        )
+      }
+    }
+
 
     if (MeanMed=='mean') {
       p <- p+ ggplot2::geom_line(ggplot2::aes(x=x, y=Mean), data=Hist_df,
@@ -209,6 +251,28 @@ plotTimeseries <- function(slick,
   # Projection
   if (byOM) {
     proj.values <- values[sims,oms,, PI,proj.yr.ind, drop=FALSE]
+
+    if (length(worm_sims) > 0) {
+      worm.values <- values[worm_sims, oms, , PI, proj.yr.ind, drop=FALSE]
+      worm_df <- data.frame(
+        Sim=rep(worm_sims, times=nOM * nMP * length(proj.yrs)),
+        OM=rep(om_names, each=length(worm_sims),
+               times=nMP * length(proj.yrs)),
+        MP=rep(MP_lab, each=length(worm_sims) * nOM,
+               times=length(proj.yrs)),
+        x=rep(proj.yrs, each=length(worm_sims) * nOM * nMP),
+        y=as.vector(worm.values)
+      )
+      worm_df$OM <- factor(worm_df$OM, levels=om_names, ordered=TRUE)
+      worm_df$MP <- factor(worm_df$MP, levels=MP_lab, ordered=TRUE)
+      p <- p + ggplot2::geom_line(
+        ggplot2::aes(
+          x=x, y=y, color=MP,
+          group=interaction(Sim, OM, MP)
+        ),
+        data=worm_df, alpha=0.25, linewidth=0.3
+      )
+    }
 
     mean.mps <- apply(proj.values, c(2,3,5), mean, na.rm=TRUE) # mean over simulations
     med.mps <- apply(proj.values, c(2,3,5), median, na.rm=TRUE) # median over simulations
@@ -277,6 +341,24 @@ plotTimeseries <- function(slick,
 
   } else {
     proj.values <- values[sims,oms,, PI,proj.yr.ind, drop=FALSE]
+
+    if (length(worm_sims) > 0) {
+      worm.values <- apply(
+        values[worm_sims, oms, , PI, proj.yr.ind, drop=FALSE],
+        c(1, 3, 5), mean, na.rm=TRUE
+      )
+      worm_df <- data.frame(
+        Sim=rep(worm_sims, times=nMP * length(proj.yrs)),
+        MP=rep(MP_lab, each=length(worm_sims), times=length(proj.yrs)),
+        x=rep(proj.yrs, each=length(worm_sims) * nMP),
+        y=as.vector(worm.values)
+      )
+      worm_df$MP <- factor(worm_df$MP, levels=MP_lab, ordered=TRUE)
+      p <- p + ggplot2::geom_line(
+        ggplot2::aes(x=x, y=y, color=MP, group=interaction(Sim, MP)),
+        data=worm_df, alpha=0.25, linewidth=0.3
+      )
+    }
     # mean over OMs
     mean.mps <- apply(proj.values, c(3,5), mean, na.rm=TRUE) # mean over simulations and OMs
     med.mps <- apply(proj.values, c(3,5), median, na.rm=TRUE) # median over simulations and OMs
@@ -340,7 +422,7 @@ plotTimeseries <- function(slick,
 
   }
 
-  X <- MP <- NULL # CRAN checks
+  X <- MP <- Sim <- OM <- NULL # CRAN checks
   if (!byMP & includeLabels) {
     tt <- data.frame(MP=MP_lab, X=sample(unique(meddf$x), nMP))
 

--- a/R/mod_Timeseries.R
+++ b/R/mod_Timeseries.R
@@ -72,7 +72,8 @@ mod_Timeseries_server <- function(id, i18n, Slick_Object, window_dims, Report,
                                   parent_session=session,
                                   includeQuants, includeLabels,
                                   includeHist,
-                                  MeanMed
+                                  MeanMed,
+                                  worms
                                   )
 
     mod_Timeseries_byMP_server("Timeseries_byMP_1", i18n, filtered_slick,
@@ -82,7 +83,8 @@ mod_Timeseries_server <- function(id, i18n, Slick_Object, window_dims, Report,
                                parent_session=session,
                                includeQuants, includeLabels,
                                includeHist,
-                               MeanMed
+                               MeanMed,
+                               worms
                                )
 
     mod_Timeseries_byOM_server("Timeseries_byOM_1", i18n, filtered_slick,
@@ -93,16 +95,18 @@ mod_Timeseries_server <- function(id, i18n, Slick_Object, window_dims, Report,
                                parent_session=session,
                                includeQuants, includeLabels,
                                includeHist,
-                               MeanMed)
+                               MeanMed,
+                               worms)
 
 
     output$plots <- renderUI({
       tagList(
         fluidRow(
-          column(3,uiOutput(ns('MeanMedian'))),
-          column(3,uiOutput(ns('includeQuantile'))),
-          column(3,uiOutput(ns('includeLabels'))),
-          column(3,uiOutput(ns('includeHist')))
+          column(2,uiOutput(ns('MeanMedian'))),
+          column(2,uiOutput(ns('includeQuantile'))),
+          column(2,uiOutput(ns('includeLabels'))),
+          column(2,uiOutput(ns('includeHist'))),
+          column(2,uiOutput(ns('worms')))
         ),
         conditionalPanel("input.plotselect=='overall'", ns=ns,
                          mod_Timeseries_overall_ui(ns("Timeseries_overall_1"))
@@ -204,6 +208,22 @@ mod_Timeseries_server <- function(id, i18n, Slick_Object, window_dims, Report,
       checkboxInput(ns('incHist'),
                     i18n$t('Include Historical?'),
                     TRUE)
+    })
+
+    output$worms <- renderUI({
+      i18n <- i18n()
+      numericInput(
+        ns("nWorms"),
+        i18n$t("Number of worms"),
+        value=10,
+        min=0,
+        step=1
+      )
+    })
+
+    worms <- reactive({
+      shiny::req(input$nWorms)
+      as.integer(input$nWorms)
     })
 
     includeQuants <- reactive({

--- a/R/mod_Timeseries_byMP.R
+++ b/R/mod_Timeseries_byMP.R
@@ -23,7 +23,7 @@ mod_Timeseries_byMP_server <- function(id, i18n, filtered_slick,
                                        window_dims,
                                        Report, parent_session,
                                        includeQuants, includeLabels, includeHist,
-                                       MeanMed
+                                       MeanMed, worms
                                        ){
   moduleServer( id, function(input, output, session){
     ns <- session$ns
@@ -92,6 +92,7 @@ mod_Timeseries_byMP_server <- function(id, i18n, filtered_slick,
                      includeLabels =includeLabels(),
                      includeHist = includeHist(),
                      MeanMed =MeanMed(),
+                     worms=worms(),
                      lang=i18n()$get_translation_language()) +
         ggplot2::coord_cartesian(ylim=yrange())
 
@@ -169,4 +170,3 @@ mod_Timeseries_byMP_server <- function(id, i18n, filtered_slick,
 
 ## To be copied in the server
 # mod_Timeseries_byMP_server("Timeseries_byMP_1")
-

--- a/R/mod_Timeseries_byOM.R
+++ b/R/mod_Timeseries_byOM.R
@@ -24,7 +24,8 @@ mod_Timeseries_byOM_server <- function(id, i18n, filtered_slick,
                                        window_dims,
                                        selected_oms,
                                        Report, parent_session,
-                                       includeQuants, includeLabels, includeHist,MeanMed){
+                                       includeQuants, includeLabels, includeHist, MeanMed,
+                                       worms){
   moduleServer( id, function(input, output, session){
     ns <- session$ns
 
@@ -106,6 +107,7 @@ mod_Timeseries_byOM_server <- function(id, i18n, filtered_slick,
                      includeLabels =includeLabels(),
                      includeHist = includeHist(),
                      MeanMed =MeanMed(),
+                     worms=worms(),
                      lang=i18n()$get_translation_language()) +
         ggplot2::coord_cartesian(ylim=yrange())
 
@@ -119,78 +121,18 @@ mod_Timeseries_byOM_server <- function(id, i18n, filtered_slick,
       out
     })
 
-    values <- reactive({
-      filtered_slick() |>
-        Timeseries() |>
-        Value()
-    })
-
-    sims <- reactive({
-      vals <-values()
-      1:dim(vals)[1]
-    })
-
     output$selections <- renderUI({
       i18n <- i18n()
       tagList(
         fluidRow(
           column(4,
-                 radioButtons(ns('plotoption'),
-                              i18n$t('Plot Option'),
-                              choiceNames = i18n$t(c('Mean', 'Individual Simulation')),
-                              choiceValues= c('median', 'sim')
-                              )
-                 ),
-          column(4,
                  checkboxInput(ns('byMP'),
                                i18n$t('by MP?'),
                                FALSE)
-          ),
-          column(4,
-                 conditionalPanel("input.plotoption=='sim'", ns=ns,
-                                  column(6,
-                                         shinyWidgets::pickerInput(
-                                           inputId = ns('selectsim'),
-                                           label = i18n$t('Individual Simulation:'),
-                                           choices = sims(),
-                                           multiple = FALSE,
-                                           width='fit'
-                                         )
-                                  ),
-                                  column(6,
-                                         shinyjs::hidden(
-                                           shinyWidgets::actionBttn(ns('updateplot'),
-                                                                    i18n$t('Update Plots'))
-                                         )
-                                  )
-                 )
           )
         )
       )
     })
-
-
-    observeEvent(input$plotoption, {
-      if (input$plotoption != 'sim') {
-        shinyjs::hide('updateplot')
-        timeseries(filtered_slick())
-      } else {
-        shinyjs::show('updateplot')
-      }
-    })
-
-    observeEvent(input$selectsim, {
-      shinyjs::show('updateplot')
-    })
-
-
-    observeEvent(input$updateplot, {
-      shinyjs::hide('updateplot')
-      slick <- filtered_slick()
-      sim <- as.numeric(input$selectsim)
-      slick@Timeseries@Value <- slick@Timeseries@Value[sim,,,,,drop=FALSE]
-      timeseries(slick)
-    }, ignoreInit = TRUE)
 
 
   })

--- a/R/mod_Timeseries_overall.R
+++ b/R/mod_Timeseries_overall.R
@@ -22,7 +22,7 @@ mod_Timeseries_overall_server <- function(id, i18n, filtered_slick,
                                           pm_ind, yrange,
                                           window_dims, Report, parent_session,
                                           includeQuants, includeLabels, includeHist,
-                                          MeanMed
+                                          MeanMed, worms
                                           ){
   moduleServer( id, function(input, output, session){
     ns <- session$ns
@@ -52,6 +52,7 @@ mod_Timeseries_overall_server <- function(id, i18n, filtered_slick,
                      includeLabels =includeLabels(),
                      includeHist = includeHist(),
                      MeanMed =MeanMed(),
+                     worms=worms(),
                      lang=i18n()$get_translation_language())
     })
 

--- a/inst/translations/translation_es.csv
+++ b/inst/translations/translation_es.csv
@@ -155,6 +155,7 @@ Y-Axis Range,Rango del eje Y
 Include MP percentiles?,¿Incluir percentiles MP?
 Include MP Labels?,¿Incluir etiquetas MP?
 Include Historical?,¿Incluir histórico?
+Number of worms,Número de trayectorias
 "This chart shows a stock status variables over time, for ",Este gráfico muestra las variables del estado de la población a lo largo del tiempo
 management procedures and level of uncertainty across,procedimientos de gestión y grado de incertidumbre en
 different simulation runs,diferentes ejecuciones de simulación

--- a/inst/translations/translation_fr.csv
+++ b/inst/translations/translation_fr.csv
@@ -155,6 +155,7 @@
 "Include MP percentiles?","Inclure les percentiles des procédures de gestion ?"
 "Include MP Labels?","Inclure les libellés des procédures de gestion ?"
 "Include Historical?","Inclure l'historique ?"
+"Number of worms","Nombre de trajectoires"
 "This chart shows a stock status variables over time, for ","Ce graphique montre les variables de l'état d'un stock dans le temps"
 "management procedures and level of uncertainty across","les procédures de gestion et le niveau d'incertitude pour"
 "different simulation runs","différentes simulations"

--- a/inst/translations/translation_pt.csv
+++ b/inst/translations/translation_pt.csv
@@ -155,6 +155,7 @@
 "Include MP percentiles?","Incluir percentis de MP?"
 "Include MP Labels?","Incluir Rótulos de MP?"
 "Include Historical?","Incluir Histórico?"
+"Number of worms","Número de trajetórias"
 "This chart shows a stock status variables over time, for ","Este gráfico mostra uma variável de estado do estoque ao longo do tempo, para "
 "management procedures and level of uncertainty across","procedimentos de manejo e nível de incerteza entre"
 "different simulation runs","diferentes execuções de simulação"

--- a/man/plotTimeseries.Rd
+++ b/man/plotTimeseries.Rd
@@ -38,6 +38,7 @@ plotTimeseries(
   lim_name = "Limit",
   inc_y_label = TRUE,
   sims = NULL,
+  worms = 10,
   lang = "en"
 )
 }
@@ -109,6 +110,9 @@ plotTimeseries(
 
 \item{sims}{Optional. Numeric values indicating the simulations to include. Defaults
 to all.}
+
+\item{worms}{Number of randomly selected individual simulation trajectories to
+overplot. Defaults to 10. Set to 0 to omit individual trajectories.}
 
 \item{lang}{Optional. Language (if supported in Slick Object). Either 'en', 'es', 'fr', or 'pt'}
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(Slick)
+
+test_check("Slick")

--- a/tests/testthat/_snaps/plotTimeseries.md
+++ b/tests/testthat/_snaps/plotTimeseries.md
@@ -1,0 +1,20 @@
+# worms must be a non-negative integer
+
+    Code
+      plotTimeseries(slick, worms = -1)
+    Message
+      i Note: `MPs` is empty. Using default MP names and colors
+    Condition
+      Error in `plotTimeseries()`:
+      ! `worms` must be a single non-negative integer.
+
+---
+
+    Code
+      plotTimeseries(slick, worms = 1.5)
+    Message
+      i Note: `MPs` is empty. Using default MP names and colors
+    Condition
+      Error in `plotTimeseries()`:
+      ! `worms` must be a single non-negative integer.
+

--- a/tests/testthat/test-plotTimeseries.R
+++ b/tests/testthat/test-plotTimeseries.R
@@ -1,0 +1,75 @@
+make_timeseries_slick <- function(nsim=12, nOM=2, nMP=2) {
+  nHist <- 3
+  nProj <- 4
+  values <- array(
+    seq_len(nsim * nOM * nMP * (nHist + nProj)),
+    dim=c(nsim, nOM, nMP, 1, nHist + nProj)
+  )
+  timeseries <- Timeseries(
+    Code="PI",
+    Label="Performance indicator",
+    Description="",
+    Time=seq_len(nHist + nProj),
+    TimeNow=nHist,
+    TimeLab="Year",
+    Value=values
+  )
+  slick <- Slick()
+  Timeseries(slick) <- timeseries
+  slick
+}
+
+test_that("plotTimeseries overplots ten randomly selected worms by default", {
+  slick <- make_timeseries_slick()
+
+  set.seed(123)
+  plot <- plotTimeseries(slick, includeLabels=FALSE)
+  worm_layers <- Filter(\(layer) "Sim" %in% names(layer$data), plot$layers)
+
+  expect_length(worm_layers, 2)
+  expect_equal(length(unique(worm_layers[[1]]$data$Sim)), 10)
+  expect_equal(
+    sort(unique(worm_layers[[1]]$data$Sim)),
+    sort(unique(worm_layers[[2]]$data$Sim))
+  )
+})
+
+test_that("worms can be disabled and are capped by available simulations", {
+  slick <- make_timeseries_slick(nsim=3)
+
+  no_worms <- plotTimeseries(slick, worms=0, includeLabels=FALSE)
+  expect_length(Filter(\(layer) "Sim" %in% names(layer$data), no_worms$layers), 0)
+
+  capped <- plotTimeseries(slick, worms=10, includeLabels=FALSE)
+  worm_layers <- Filter(\(layer) "Sim" %in% names(layer$data), capped$layers)
+  expect_equal(length(unique(worm_layers[[1]]$data$Sim)), 3)
+
+  one_sim <- plotTimeseries(
+    slick, sims=3, worms=10, includeLabels=FALSE
+  )
+  worm_layers <- Filter(\(layer) "Sim" %in% names(layer$data), one_sim$layers)
+  expect_equal(unique(worm_layers[[1]]$data$Sim), 3)
+})
+
+test_that("worm trajectories retain OM and MP grouping variables", {
+  slick <- make_timeseries_slick()
+
+  plot <- plotTimeseries(
+    slick, byOM=TRUE, byMP=TRUE, worms=4, includeLabels=FALSE
+  )
+  worm_layers <- Filter(\(layer) "Sim" %in% names(layer$data), plot$layers)
+
+  expect_named(
+    worm_layers[[2]]$data,
+    c("Sim", "OM", "MP", "x", "y"),
+    ignore.order=TRUE
+  )
+  expect_equal(length(unique(worm_layers[[2]]$data$Sim)), 4)
+})
+
+test_that("worms must be a non-negative integer", {
+  slick <- make_timeseries_slick()
+
+  expect_snapshot(error=TRUE, plotTimeseries(slick, worms=-1))
+  expect_snapshot(error=TRUE, plotTimeseries(slick, worms=1.5))
+})


### PR DESCRIPTION
## Summary

- overplot a random sample of individual simulation trajectories on time-series plots
- default to 10 worms, with `worms = 0` available to disable them
- expose the worm count across all time-series views and replace the single-run selector
- add translated labels, documentation, NEWS, and focused tests

## Why

Showing only one individual run provides a narrow view of simulation variability. A configurable random sample makes the range and shape of individual trajectories visible alongside the existing summaries and percentile ribbons.

## Validation

- `devtools::test()` — 10 tests passed
- `devtools::check(document = FALSE, manual = FALSE, cran = FALSE)` — 0 errors, 0 warnings, 0 notes
- rendered all combinations of overall/by-MP/by-OM views with and without historical values
